### PR TITLE
Give response to genCacheKey function

### DIFF
--- a/express-expeditious.d.ts
+++ b/express-expeditious.d.ts
@@ -29,7 +29,7 @@ declare namespace ExpressExpeditious {
    * Function that can be used to generate a custom caching key for an incoming request. This key will be used to read
    * and write from the cache
    */
-  type GenreateCacheKeyFunction = (req: express.Request) => string
+  type GenreateCacheKeyFunction = (req: express.Request, res: express.Response) => string
 
   /**
    * Options that must be passed to the factory function of express-expeditious

--- a/lib/cache-key.js
+++ b/lib/cache-key.js
@@ -4,11 +4,12 @@ module.exports = function getCacheKeyGenerator (opts) {
   /**
    * Generate the key to use for caching this request
    * @param  {IncomingRequest} req
+   * @param  {OutgoingResponse} res
    * @return {String}
    */
   return function genCacheKey (req, res) {
     if (opts.genCacheKey) {
-      return opts.genCacheKey(req)
+      return opts.genCacheKey(req, res)
     } else {
       const etag = res.finished
         ? res.get('etag') : req.headers['if-none-match']


### PR DESCRIPTION
This is so users with custom `getCacheKey` functions can use the same etag fix
from: https://github.com/evanshortiss/express-expeditious/blob/master/lib/cache-key.js#L13